### PR TITLE
Set validate params optional

### DIFF
--- a/lib/envee.rb
+++ b/lib/envee.rb
@@ -47,7 +47,7 @@ module Envee
     Time.at(value).utc
   end
 
-  def validate!(options)
+  def validate!(options={})
     missing = options[:placeholder] || 'CHANGEME'
     missing_keys = select{|_k, v| v.include?(missing)}.map(&:first)
     raise MissingValuesError, missing_keys unless missing_keys.empty?


### PR DESCRIPTION
The options parameter in validate should be optional, based on the first line in the method. Otherwise need to pass in a reduntant empty hash as a parameter.